### PR TITLE
Port to Zig 0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .zig-cache/
 zig-out/
+zig-pkg/
 example
 example.o
 history.txt

--- a/build.zig
+++ b/build.zig
@@ -25,11 +25,11 @@ pub fn build(b: *Build) void {
             .root_source_file = b.path("src/c.zig"),
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
         .linkage = .static,
     });
     lib.root_module.addImport("wcwidth", wcwidth);
-    lib.linkLibC();
     b.installArtifact(lib);
 
     // Tests
@@ -64,12 +64,12 @@ pub fn build(b: *Build) void {
         .root_module = b.createModule(.{
             .target = target,
             .optimize = optimize,
+            .link_libc = true,
         }),
     });
     c_example.root_module.addCSourceFile(.{ .file = b.path("examples/example.c") });
-    c_example.addIncludePath(b.path("include"));
-    c_example.linkLibC();
-    c_example.linkLibrary(lib);
+    c_example.root_module.addIncludePath(b.path("include"));
+    c_example.root_module.linkLibrary(lib);
 
     var c_example_run = b.addRunArtifact(c_example);
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -14,7 +14,7 @@
         "build.zig",
         "build.zig.zon",
         "examples/",
-        "includes/",
+        "include/",
         "src/",
     },
 }

--- a/src/c.zig
+++ b/src/c.zig
@@ -144,13 +144,13 @@ export fn linenoiseHistorySetMaxLen(len: c_int) c_int {
 
 export fn linenoiseHistorySave(filename: [*:0]const u8) c_int {
     if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
-    global_linenoise.?.history.save(mem.span(filename)) catch return -1;
+    global_linenoise.?.history.save(mem.span(filename), global_linenoise.?.io) catch return -1;
     return 0;
 }
 
 export fn linenoiseHistoryLoad(filename: [*:0]const u8) c_int {
     if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
-    global_linenoise.?.history.load(mem.span(filename)) catch return -1;
+    global_linenoise.?.history.load(mem.span(filename), global_linenoise.?.io) catch return -1;
     return 0;
 }
 

--- a/src/c.zig
+++ b/src/c.zig
@@ -7,7 +7,18 @@ const Linenoise = @import("main.zig").Linenoise;
 const term = @import("term.zig");
 
 const global_allocator = std.heap.c_allocator;
+const global_io = std.Io.Threaded.global_single_threaded.io();
+var global_environ_map: std.process.Environ.Map = undefined;
+var global_is_initialized = false;
 var global_linenoise: ?Linenoise = null;
+
+fn ensureInit() void {
+    if (!global_is_initialized) {
+        global_environ_map = std.process.Environ.Map.init(global_allocator);
+        global_linenoise = Linenoise.init(global_allocator, global_io, &global_environ_map);
+        global_is_initialized = true;
+    }
+}
 
 var c_completion_callback: ?linenoiseCompletionCallback = null;
 var c_hints_callback: ?linenoiseHintsCallback = null;
@@ -32,13 +43,13 @@ const linenoiseFreeHintsCallback = *const fn (*anyopaque) callconv(.c) void;
 
 export fn linenoiseSetCompletionCallback(fun: linenoiseCompletionCallback) void {
     c_completion_callback = fun;
-    if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
+    ensureInit();
     global_linenoise.?.completions_callback = completionsCallback;
 }
 
 export fn linenoiseSetHintsCallback(fun: linenoiseHintsCallback) void {
     c_hints_callback = fun;
-    if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
+    ensureInit();
     global_linenoise.?.hints_callback = hintsCallback;
 }
 
@@ -118,7 +129,7 @@ fn hintsCallback(allocator: Allocator, line: []const u8) !?[]const u8 {
 }
 
 export fn linenoise(prompt: [*:0]const u8) ?[*:0]u8 {
-    if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
+    ensureInit();
     const result = global_linenoise.?.linenoise(mem.span(prompt)) catch return null;
     if (result) |line| {
         defer global_allocator.free(line);
@@ -131,35 +142,35 @@ export fn linenoiseFree(ptr: *anyopaque) void {
 }
 
 export fn linenoiseHistoryAdd(line: [*:0]const u8) c_int {
-    if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
+    ensureInit();
     global_linenoise.?.history.add(mem.span(line)) catch return -1;
     return 0;
 }
 
 export fn linenoiseHistorySetMaxLen(len: c_int) c_int {
-    if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
+    ensureInit();
     global_linenoise.?.history.setMaxLen(@intCast(len));
     return 0;
 }
 
 export fn linenoiseHistorySave(filename: [*:0]const u8) c_int {
-    if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
+    ensureInit();
     global_linenoise.?.history.save(mem.span(filename), global_linenoise.?.io) catch return -1;
     return 0;
 }
 
 export fn linenoiseHistoryLoad(filename: [*:0]const u8) c_int {
-    if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
+    ensureInit();
     global_linenoise.?.history.load(mem.span(filename), global_linenoise.?.io) catch return -1;
     return 0;
 }
 
 export fn linenoiseClearScreen() void {
-    term.clearScreen() catch return;
+    if (global_linenoise) |*ln| term.clearScreen(ln.io) catch return;
 }
 
 export fn linenoiseSetMultiLine(ml: c_int) void {
-    if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
+    ensureInit();
     global_linenoise.?.multiline_mode = ml != 0;
 }
 
@@ -167,11 +178,11 @@ export fn linenoiseSetMultiLine(ml: c_int) void {
 export fn linenoisePrintKeyCodes() void {}
 
 export fn linenoiseMaskModeEnable() void {
-    if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
+    ensureInit();
     global_linenoise.?.mask_mode = true;
 }
 
 export fn linenoiseMaskModeDisable() void {
-    if (global_linenoise == null) global_linenoise = Linenoise.init(global_allocator);
+    ensureInit();
     global_linenoise.?.mask_mode = false;
 }

--- a/src/history.zig
+++ b/src/history.zig
@@ -1,6 +1,9 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ArrayListUnmanaged = std.ArrayListUnmanaged;
+const Io = std.Io;
+const File = Io.File;
+const Dir = Io.Dir;
 
 const max_line_len = 4096;
 
@@ -54,12 +57,12 @@ pub const History = struct {
     }
 
     /// Loads the history from a file
-    pub fn load(self: *Self, path: []const u8) !void {
-        const file = try std.fs.cwd().openFile(path, .{});
-        defer file.close();
+    pub fn load(self: *Self, path: []const u8, io: Io) !void {
+        const file = try Dir.cwd().openFile(io, path, .{});
+        defer file.close(io);
 
         var read_buf: [4096]u8 = undefined;
-        var reader = file.reader(&read_buf);
+        var reader = file.reader(io, &read_buf);
         while (true) {
             const maybe_line = reader.interface.takeDelimiter('\n') catch |err| switch (err) {
                 error.StreamTooLong => return err,
@@ -73,13 +76,13 @@ pub const History = struct {
     }
 
     /// Saves the history to a file
-    pub fn save(self: *Self, path: []const u8) !void {
-        const file = try std.fs.cwd().createFile(path, .{});
-        defer file.close();
+    pub fn save(self: *Self, path: []const u8, io: Io) !void {
+        const file = try Dir.cwd().createFile(io, path, .{});
+        defer file.close(io);
 
         for (self.hist.items) |line| {
-            try file.writeAll(line);
-            try file.writeAll("\n");
+            try file.writeStreamingAll(io, line);
+            try file.writeStreamingAll(io, "\n");
         }
     }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,7 +1,8 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
-const File = std.fs.File;
+const File = std.Io.File;
+const Io = std.Io;
 
 const LinenoiseState = @import("state.zig").LinenoiseState;
 pub const History = @import("history.zig").History;
@@ -41,7 +42,7 @@ fn editCsi(state: *LinenoiseState) !void {
     if ((try term.read(in, &input_buf)) < 1) return error.EndOfFile;
     switch (input_buf[0]) {
         '0'...'9' => |num| {
-            if ((try in.read(&input_buf)) < 1) return error.EndOfFile;
+            if ((try term.read(in, &input_buf)) < 1) return error.EndOfFile;
             switch (input_buf[0]) {
                 '~' => switch (num) {
                     '1', '7' => try state.editMoveHome(),
@@ -51,7 +52,7 @@ fn editCsi(state: *LinenoiseState) !void {
                 },
                 ';' => switch (num) {
                     '1' => {
-                        if ((try in.read(&input_buf)) < 1) return error.EndOfFile;
+                        if ((try term.read(in, &input_buf)) < 1) return error.EndOfFile;
                         switch (input_buf[0]) {
                             '5' => {
                                 if ((try term.read(in, &input_buf)) < 1) return error.EndOfFile;
@@ -170,22 +171,22 @@ fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]co
 
 /// Read a line with custom line editing mechanics. This includes hints,
 /// completions and history
-fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
+fn linenoiseRaw(ln: *Linenoise, in: File, out: File, io: Io, prompt: []const u8) !?[]const u8 {
     defer {
         if (ln.print_newline)
-            out.writeAll("\n") catch {};
+            out.writeStreamingAll(io, "\n") catch {};
     }
 
-    const orig = try enableRawMode(in, out);
-    defer disableRawMode(in, out, orig);
+    const orig = try enableRawMode(io, in, out);
+    defer disableRawMode(io, in, out, orig);
 
     return try linenoiseEdit(ln, in, out, prompt);
 }
 
 /// Read a line with no special features (no hints, no completions, no history)
-fn linenoiseNoTTY(allocator: Allocator, stdin: File) !?[]const u8 {
+fn linenoiseNoTTY(allocator: Allocator, stdin: File, io: Io) !?[]const u8 {
     var read_buf: [4096]u8 = undefined;
-    var reader = stdin.readerStreaming(&read_buf);
+    var reader = stdin.readerStreaming(io, &read_buf);
     const maybe_line = reader.interface.takeDelimiter('\n') catch |err| switch (err) {
         error.StreamTooLong => return err,
         error.ReadFailed => return err,
@@ -196,6 +197,7 @@ fn linenoiseNoTTY(allocator: Allocator, stdin: File) !?[]const u8 {
 
 pub const Linenoise = struct {
     allocator: Allocator,
+    io: Io,
     history: History,
     multiline_mode: bool = false,
     mask_mode: bool = false,
@@ -212,15 +214,17 @@ pub const Linenoise = struct {
 
     /// Initialize a linenoise struct
     pub fn init(allocator: Allocator) Self {
-        return initWithFiles(allocator, std.fs.File.stdin(), std.fs.File.stdout());
+        return initWithFiles(allocator, File.stdin(), File.stdout());
     }
 
     /// Initialize a linenoise struct with specific input and output streams
     /// Use this method to connect linenoise to the files of your choosing
     /// like /dev/tty on Linux or \\.\CONIN$ on Windows
-    pub fn initWithFiles(allocator: Allocator, input: std.fs.File, output: std.fs.File) Self {
+    pub fn initWithFiles(allocator: Allocator, input: File, output: File) Self {
+        const io = Io.Threaded.global_single_threaded.io();
         var self = Self{
             .allocator = allocator,
+            .io = io,
             .history = History.empty(allocator),
             .stdin_file = input,
             .stdout_file = output,
@@ -238,20 +242,20 @@ pub const Linenoise = struct {
     /// check if line editing and prompt printing should be
     /// enabled or not.
     pub fn examineStdIo(self: *Self) void {
-        self.is_tty = self.stdin_file.isTty();
-        self.term_supported = !isUnsupportedTerm(self.allocator);
+        self.is_tty = self.stdin_file.isTty(self.io) catch false;
+        self.term_supported = !isUnsupportedTerm();
     }
 
     /// Reads a line from the terminal. Caller owns returned memory
     pub fn linenoise(self: *Self, prompt: []const u8) !?[]const u8 {
         if (self.is_tty and !self.term_supported) {
-            try self.stdout_file.writeAll(prompt);
+            try self.stdout_file.writeStreamingAll(self.io, prompt);
         }
 
         return if (self.is_tty and self.term_supported)
-            try linenoiseRaw(self, self.stdin_file, self.stdout_file, prompt)
+            try linenoiseRaw(self, self.stdin_file, self.stdout_file, self.io, prompt)
         else
-            try linenoiseNoTTY(self.allocator, self.stdin_file);
+            try linenoiseNoTTY(self.allocator, self.stdin_file, self.io);
     }
 };
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -7,7 +7,6 @@ const Io = std.Io;
 const LinenoiseState = @import("state.zig").LinenoiseState;
 pub const History = @import("history.zig").History;
 const term = @import("term.zig");
-const isUnsupportedTerm = term.isUnsupportedTerm;
 const enableRawMode = term.enableRawMode;
 const disableRawMode = term.disableRawMode;
 const getColumns = term.getColumns;
@@ -139,7 +138,7 @@ fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]co
             key_ctrl_f => try state.editMoveRight(),
             key_ctrl_k => try state.editKillLineForward(),
             key_ctrl_l => {
-                try term.clearScreen();
+                try term.clearScreen(ln.io);
                 try state.refreshLine();
             },
             key_enter => {
@@ -171,33 +170,34 @@ fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]co
 
 /// Read a line with custom line editing mechanics. This includes hints,
 /// completions and history
-fn linenoiseRaw(ln: *Linenoise, in: File, out: File, io: Io, prompt: []const u8) !?[]const u8 {
+fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
     defer {
         if (ln.print_newline)
-            out.writeStreamingAll(io, "\n") catch {};
+            out.writeStreamingAll(ln.io, "\n") catch {};
     }
 
-    const orig = try enableRawMode(io, in, out);
-    defer disableRawMode(io, in, out, orig);
+    const orig = try enableRawMode(ln.io, in, out);
+    defer disableRawMode(ln.io, in, out, orig);
 
     return try linenoiseEdit(ln, in, out, prompt);
 }
 
 /// Read a line with no special features (no hints, no completions, no history)
-fn linenoiseNoTTY(allocator: Allocator, stdin: File, io: Io) !?[]const u8 {
+fn linenoiseNoTTY(ln: *Linenoise, stdin: File) !?[]const u8 {
     var read_buf: [4096]u8 = undefined;
-    var reader = stdin.readerStreaming(io, &read_buf);
+    var reader = stdin.readerStreaming(ln.io, &read_buf);
     const maybe_line = reader.interface.takeDelimiter('\n') catch |err| switch (err) {
         error.StreamTooLong => return err,
         error.ReadFailed => return err,
     };
     const line = maybe_line orelse return null;
-    return try allocator.dupe(u8, line);
+    return try ln.allocator.dupe(u8, line);
 }
 
 pub const Linenoise = struct {
     allocator: Allocator,
     io: Io,
+    environ_map: *const std.process.Environ.Map,
     history: History,
     multiline_mode: bool = false,
     mask_mode: bool = false,
@@ -213,18 +213,18 @@ pub const Linenoise = struct {
     const Self = @This();
 
     /// Initialize a linenoise struct
-    pub fn init(allocator: Allocator) Self {
-        return initWithFiles(allocator, File.stdin(), File.stdout());
+    pub fn init(allocator: Allocator, io: Io, environ: *const std.process.Environ.Map) Self {
+        return initWithFiles(allocator, io, environ, File.stdin(), File.stdout());
     }
 
     /// Initialize a linenoise struct with specific input and output streams
     /// Use this method to connect linenoise to the files of your choosing
     /// like /dev/tty on Linux or \\.\CONIN$ on Windows
-    pub fn initWithFiles(allocator: Allocator, input: File, output: File) Self {
-        const io = Io.Threaded.global_single_threaded.io();
+    pub fn initWithFiles(allocator: Allocator, io: Io, environ: *const std.process.Environ.Map, input: File, output: File) Self {
         var self = Self{
             .allocator = allocator,
             .io = io,
+            .environ_map = environ,
             .history = History.empty(allocator),
             .stdin_file = input,
             .stdout_file = output,
@@ -243,7 +243,7 @@ pub const Linenoise = struct {
     /// enabled or not.
     pub fn examineStdIo(self: *Self) void {
         self.is_tty = self.stdin_file.isTty(self.io) catch false;
-        self.term_supported = !isUnsupportedTerm();
+        self.term_supported = !term.isUnsupportedTerm(self.environ_map);
     }
 
     /// Reads a line from the terminal. Caller owns returned memory
@@ -253,9 +253,9 @@ pub const Linenoise = struct {
         }
 
         return if (self.is_tty and self.term_supported)
-            try linenoiseRaw(self, self.stdin_file, self.stdout_file, self.io, prompt)
+            try linenoiseRaw(self, self.stdin_file, self.stdout_file, prompt)
         else
-            try linenoiseNoTTY(self.allocator, self.stdin_file, self.io);
+            try linenoiseNoTTY(self, self.stdin_file);
     }
 };
 

--- a/src/state.zig
+++ b/src/state.zig
@@ -155,7 +155,7 @@ pub const LinenoiseState = struct {
         }
 
         if (completions.len == 0) {
-            try term.beep();
+            try term.beep(self.ln.io);
         } else {
             var finished = false;
             var i: usize = 0;
@@ -191,7 +191,7 @@ pub const LinenoiseState = struct {
                     key_tab => {
                         // Next completion
                         i = (i + 1) % (completions.len + 1);
-                        if (i == completions.len) try term.beep();
+                        if (i == completions.len) try term.beep(self.ln.io);
                     },
                     key_esc => {
                         // Stop browsing completions, return to buffer displayed
@@ -206,7 +206,7 @@ pub const LinenoiseState = struct {
                             // Replace buffer with text in the selected
                             // completion
                             self.buf.deinit(self.allocator);
-                    self.buf = .empty;
+                            self.buf = .empty;
                             try self.buf.appendSlice(self.allocator, completions[i]);
 
                             self.pos = self.buf.items.len;

--- a/src/state.zig
+++ b/src/state.zig
@@ -2,7 +2,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 const ArrayList = std.ArrayList;
 const ArrayListUnmanaged = std.ArrayListUnmanaged;
-const File = std.fs.File;
+const File = std.Io.File;
 const math = std.math;
 
 const Linenoise = @import("main.zig").Linenoise;
@@ -139,7 +139,7 @@ pub const LinenoiseState = struct {
             .stdin = in,
             .stdout = out,
             .prompt = prompt,
-            .cols = getColumns(in, out) catch 80,
+            .cols = getColumns(ln.io, in, out) catch 80,
         };
     }
 
@@ -168,7 +168,7 @@ pub const LinenoiseState = struct {
                     const old_pos = self.pos;
 
                     // Show suggested completion
-                    self.buf = .{};
+                    self.buf = .empty;
                     try self.buf.appendSlice(self.allocator, completions[i]);
                     self.pos = self.buf.items.len;
 
@@ -184,7 +184,7 @@ pub const LinenoiseState = struct {
                 }
 
                 // Read next key
-                const nread = try self.stdin.read(&input_buf);
+                const nread = try term.read(self.stdin, &input_buf);
                 c = if (nread == 1) input_buf[0] else return error.NothingRead;
 
                 switch (c.?) {
@@ -206,7 +206,7 @@ pub const LinenoiseState = struct {
                             // Replace buffer with text in the selected
                             // completion
                             self.buf.deinit(self.allocator);
-                            self.buf = .{};
+                    self.buf = .empty;
                             try self.buf.appendSlice(self.allocator, completions[i]);
 
                             self.pos = self.buf.items.len;
@@ -230,7 +230,7 @@ pub const LinenoiseState = struct {
 
     fn refreshSingleLine(self: *Self) !void {
         var write_buf: [4096]u8 = undefined;
-        var file_writer = self.stdout.writerStreaming(&write_buf);
+        var file_writer = self.stdout.writerStreaming(self.ln.io, &write_buf);
         var writer = &file_writer.interface;
 
         const hint = try self.getHint();
@@ -312,7 +312,7 @@ pub const LinenoiseState = struct {
 
     fn refreshMultiLine(self: *Self) !void {
         var write_buf: [4096]u8 = undefined;
-        var file_writer = self.stdout.writerStreaming(&write_buf);
+        var file_writer = self.stdout.writerStreaming(self.ln.io, &write_buf);
         var writer = &file_writer.interface;
 
         const hint = try self.getHint();
@@ -503,7 +503,7 @@ pub const LinenoiseState = struct {
 
             // Copy history entry to the current line buffer
             self.buf.deinit(self.allocator);
-            self.buf = .{};
+            self.buf = .empty;
             try self.buf.appendSlice(self.allocator, self.ln.history.hist.items[new_index]);
             self.pos = self.buf.items.len;
 

--- a/src/term.zig
+++ b/src/term.zig
@@ -8,10 +8,10 @@ const is_windows = builtin.os.tag == .windows;
 const termios = if (!is_windows) std.posix.termios else struct { inMode: w.DWORD, outMode: w.DWORD };
 const Io = std.Io;
 
-pub fn isUnsupportedTerm() bool {
-    const env_var = std.c.getenv("TERM") orelse return false;
+pub fn isUnsupportedTerm(environ: *const std.process.Environ.Map) bool {
+    const env_var = environ.get("TERM") orelse return false;
     return for (unsupported_term) |t| {
-        if (std.ascii.eqlIgnoreCase(std.mem.sliceTo(env_var, 0), t))
+        if (std.ascii.eqlIgnoreCase(env_var, t))
             break true;
     } else false;
 }
@@ -24,6 +24,8 @@ const w = if (is_windows) struct {
     pub const BOOL = windows.BOOL;
     pub const HANDLE = windows.HANDLE;
     pub const WCHAR = windows.WCHAR;
+
+    // These structs were removed from std.os.windows in 0.16.0, we are adding it back here https://codeberg.org/ziglang/zig/commit/c77e7146f5fa8e83c06cd6612b7298df06912974
     pub const CONSOLE_SCREEN_BUFFER_INFO = extern struct {
         dwSize: windows.COORD,
         dwCursorPosition: windows.COORD,
@@ -37,6 +39,7 @@ const w = if (is_windows) struct {
         Right: windows.SHORT,
         Bottom: windows.SHORT,
     };
+
     pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING = windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     pub const ENABLE_VIRTUAL_TERMINAL_INPUT = @as(c_int, 0x200);
     pub const CP_UTF8 = @as(c_int, 65001);
@@ -194,14 +197,14 @@ pub fn getColumns(io: Io, in: File, out: File) !usize {
     }
 }
 
-pub fn clearScreen() !void {
+pub fn clearScreen(io: Io) !void {
     const stderr = File.stderr();
-    try stderr.writeStreamingAll(std.Io.Threaded.global_single_threaded.io(), "\x1b[H\x1b[2J");
+    try stderr.writeStreamingAll(io, "\x1b[H\x1b[2J");
 }
 
-pub fn beep() !void {
+pub fn beep(io: Io) !void {
     const stderr = File.stderr();
-    try stderr.writeStreamingAll(std.Io.Threaded.global_single_threaded.io(), "\x07");
+    try stderr.writeStreamingAll(io, "\x07");
 }
 
 var utf8ConsoleBuffer = [_]u8{0} ** 10;

--- a/src/term.zig
+++ b/src/term.zig
@@ -1,17 +1,17 @@
 const std = @import("std");
 const builtin = @import("builtin");
-const File = std.fs.File;
+const File = std.Io.File;
 
 const unsupported_term = [_][]const u8{ "dumb", "cons25", "emacs" };
 
 const is_windows = builtin.os.tag == .windows;
 const termios = if (!is_windows) std.posix.termios else struct { inMode: w.DWORD, outMode: w.DWORD };
+const Io = std.Io;
 
-pub fn isUnsupportedTerm(allocator: std.mem.Allocator) bool {
-    const env_var = std.process.getEnvVarOwned(allocator, "TERM") catch return false;
-    defer allocator.free(env_var);
+pub fn isUnsupportedTerm() bool {
+    const env_var = std.c.getenv("TERM") orelse return false;
     return for (unsupported_term) |t| {
-        if (std.ascii.eqlIgnoreCase(env_var, t))
+        if (std.ascii.eqlIgnoreCase(std.mem.sliceTo(env_var, 0), t))
             break true;
     } else false;
 }
@@ -24,8 +24,19 @@ const w = if (is_windows) struct {
     pub const BOOL = windows.BOOL;
     pub const HANDLE = windows.HANDLE;
     pub const WCHAR = windows.WCHAR;
-    pub const WINAPI = windows.WINAPI;
-    pub const CONSOLE_SCREEN_BUFFER_INFO = windows.CONSOLE_SCREEN_BUFFER_INFO;
+    pub const CONSOLE_SCREEN_BUFFER_INFO = extern struct {
+        dwSize: windows.COORD,
+        dwCursorPosition: windows.COORD,
+        wAttributes: windows.WORD,
+        srWindow: SMALL_RECT,
+        dwMaximumWindowSize: windows.COORD,
+    };
+    const SMALL_RECT = extern struct {
+        Left: windows.SHORT,
+        Top: windows.SHORT,
+        Right: windows.SHORT,
+        Bottom: windows.SHORT,
+    };
     pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING = windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     pub const ENABLE_VIRTUAL_TERMINAL_INPUT = @as(c_int, 0x200);
     pub const CP_UTF8 = @as(c_int, 65001);
@@ -40,7 +51,6 @@ const w = if (is_windows) struct {
     pub const BOOL = i32;
     pub const HANDLE = *anyopaque;
     pub const WCHAR = u16;
-    pub const WINAPI = void;
     pub const CONSOLE_SCREEN_BUFFER_INFO = void;
     pub const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0;
     pub const ENABLE_VIRTUAL_TERMINAL_INPUT = @as(c_int, 0x200);
@@ -52,17 +62,17 @@ const w = if (is_windows) struct {
 };
 
 const k32 = if (is_windows) struct {
-    const kernel32 = std.os.windows.kernel32;
-    pub const GetConsoleMode = kernel32.GetConsoleMode;
-    pub const SetConsoleMode = kernel32.SetConsoleMode;
-    pub const SetConsoleOutputCP = kernel32.SetConsoleOutputCP;
-    pub const GetConsoleScreenBufferInfo = kernel32.GetConsoleScreenBufferInfo;
-    pub extern "kernel32" fn SetConsoleCP(wCodePageID: w.UINT) callconv(w.WINAPI) w.BOOL;
-    pub extern "kernel32" fn PeekConsoleInputW(hConsoleInput: w.HANDLE, lpBuffer: [*]w.INPUT_RECORD, nLength: w.DWORD, lpNumberOfEventsRead: ?*w.DWORD) callconv(w.WINAPI) w.BOOL;
-    pub extern "kernel32" fn ReadConsoleW(hConsoleInput: w.HANDLE, lpBuffer: [*]u16, nNumberOfCharsToRead: w.DWORD, lpNumberOfCharsRead: ?*w.DWORD, lpReserved: ?*anyopaque) callconv(w.WINAPI) w.BOOL;
+    pub extern "kernel32" fn GetConsoleMode(hConsoleHandle: w.HANDLE, lpMode: *w.DWORD) callconv(.winapi) w.BOOL;
+    pub extern "kernel32" fn SetConsoleMode(hConsoleHandle: w.HANDLE, dwMode: w.DWORD) callconv(.winapi) w.BOOL;
+    pub extern "kernel32" fn SetConsoleOutputCP(wCodePageID: w.UINT) callconv(.winapi) w.BOOL;
+    pub extern "kernel32" fn GetConsoleScreenBufferInfo(hConsoleOutput: w.HANDLE, lpConsoleScreenBufferInfo: *w.CONSOLE_SCREEN_BUFFER_INFO) callconv(.winapi) w.BOOL;
+    pub extern "kernel32" fn SetConsoleCP(wCodePageID: w.UINT) callconv(.winapi) w.BOOL;
+    pub extern "kernel32" fn PeekConsoleInputW(hConsoleInput: w.HANDLE, lpBuffer: [*]w.INPUT_RECORD, nLength: w.DWORD, lpNumberOfEventsRead: ?*w.DWORD) callconv(.winapi) w.BOOL;
+    pub extern "kernel32" fn ReadConsoleW(hConsoleInput: w.HANDLE, lpBuffer: [*]u16, nNumberOfCharsToRead: w.DWORD, lpNumberOfCharsRead: ?*w.DWORD, lpReserved: ?*anyopaque) callconv(.winapi) w.BOOL;
 } else struct {};
 
-pub fn enableRawMode(in: File, out: File) !termios {
+pub fn enableRawMode(io: Io, in: File, out: File) !termios {
+    _ = io;
     if (is_windows) {
         var result: termios = .{
             .inMode = 0,
@@ -70,9 +80,9 @@ pub fn enableRawMode(in: File, out: File) !termios {
         };
         var irec: [1]w.INPUT_RECORD = undefined;
         var n: w.DWORD = 0;
-        if (k32.PeekConsoleInputW(in.handle, &irec, 1, &n) == 0 or
-            k32.GetConsoleMode(in.handle, &result.inMode) == 0 or
-            k32.GetConsoleMode(out.handle, &result.outMode) == 0)
+        if (k32.PeekConsoleInputW(in.handle, &irec, 1, &n) == .FALSE or
+            k32.GetConsoleMode(in.handle, &result.inMode) == .FALSE or
+            k32.GetConsoleMode(out.handle, &result.outMode) == .FALSE)
             return error.InitFailed;
         _ = k32.SetConsoleMode(in.handle, w.ENABLE_VIRTUAL_TERMINAL_INPUT);
         _ = k32.SetConsoleMode(out.handle, result.outMode | w.ENABLE_VIRTUAL_TERMINAL_PROCESSING);
@@ -108,7 +118,8 @@ pub fn enableRawMode(in: File, out: File) !termios {
     }
 }
 
-pub fn disableRawMode(in: File, out: File, orig: termios) void {
+pub fn disableRawMode(io: Io, in: File, out: File, orig: termios) void {
+    _ = io;
     if (is_windows) {
         _ = k32.SetConsoleMode(in.handle, orig.inMode);
         _ = k32.SetConsoleMode(out.handle, orig.outMode);
@@ -117,16 +128,16 @@ pub fn disableRawMode(in: File, out: File, orig: termios) void {
     }
 }
 
-fn getCursorPosition(in: File, out: File) !usize {
+fn getCursorPosition(io: Io, in: File, out: File) !usize {
     var buf: [32]u8 = undefined;
 
     // Tell terminal to report cursor to in
-    try out.writeAll("\x1B[6n");
+    try out.writeStreamingAll(io, "\x1B[6n");
 
     // Read answer
     var total: usize = 0;
     while (total < buf.len) {
-        const n = try in.read(buf[total .. total + 1]);
+        const n = try read(in, buf[total .. total + 1]);
         if (n == 0) return error.CursorPos;
         if (buf[total] == 'R') break;
         total += 1;
@@ -145,20 +156,20 @@ fn getCursorPosition(in: File, out: File) !usize {
     return try std.fmt.parseInt(usize, x, 10);
 }
 
-fn getColumnsFallback(in: File, out: File) !usize {
-    const orig_cursor_pos = try getCursorPosition(in, out);
+fn getColumnsFallback(io: Io, in: File, out: File) !usize {
+    const orig_cursor_pos = try getCursorPosition(io, in, out);
 
-    try out.writeAll("\x1B[999C");
-    const cols = try getCursorPosition(in, out);
+    try out.writeStreamingAll(io, "\x1B[999C");
+    const cols = try getCursorPosition(io, in, out);
 
     var move_buf: [32]u8 = undefined;
     const move_str = std.fmt.bufPrint(&move_buf, "\x1B[{}D", .{orig_cursor_pos}) catch return error.CursorPos;
-    try out.writeAll(move_str);
+    try out.writeStreamingAll(io, move_str);
 
     return cols;
 }
 
-pub fn getColumns(in: File, out: File) !usize {
+pub fn getColumns(io: Io, in: File, out: File) !usize {
     switch (builtin.os.tag) {
         .windows => {
             var csbi: w.CONSOLE_SCREEN_BUFFER_INFO = undefined;
@@ -177,20 +188,20 @@ pub fn getColumns(in: File, out: File) !usize {
             if (std.posix.errno(err) == .SUCCESS and winsize.col > 0) {
                 return winsize.col;
             } else {
-                return try getColumnsFallback(in, out);
+                return try getColumnsFallback(io, in, out);
             }
         },
     }
 }
 
 pub fn clearScreen() !void {
-    const stderr = std.fs.File.stderr();
-    try stderr.writeAll("\x1b[H\x1b[2J");
+    const stderr = File.stderr();
+    try stderr.writeStreamingAll(std.Io.Threaded.global_single_threaded.io(), "\x1b[H\x1b[2J");
 }
 
 pub fn beep() !void {
-    const stderr = std.fs.File.stderr();
-    try stderr.writeAll("\x07");
+    const stderr = File.stderr();
+    try stderr.writeStreamingAll(std.Io.Threaded.global_single_threaded.io(), "\x07");
 }
 
 var utf8ConsoleBuffer = [_]u8{0} ** 10;
@@ -211,13 +222,13 @@ fn readWin32Console(self: File, buffer: []u8) !usize {
         }
         var charsRead: w.DWORD = 0;
         var wideBuf: [2]w.WCHAR = undefined;
-        if (k32.ReadConsoleW(self.handle, &wideBuf, 1, &charsRead, null) == 0)
+        if (k32.ReadConsoleW(self.handle, &wideBuf, 1, &charsRead, null) == .FALSE)
             return 0;
         if (charsRead == 0)
             break;
         const wideBufLen: u8 = if (wideBuf[0] >= 0xD800 and wideBuf[0] <= 0xDBFF) _: {
             // read surrogate
-            if (k32.ReadConsoleW(self.handle, wideBuf[1..], 1, &charsRead, null) == 0)
+            if (k32.ReadConsoleW(self.handle, wideBuf[1..], 1, &charsRead, null) == .FALSE)
                 return 0;
             if (charsRead == 0)
                 break;
@@ -229,4 +240,8 @@ fn readWin32Console(self: File, buffer: []u8) !usize {
     return buffer.len - toRead;
 }
 
-pub const read = if (is_windows) readWin32Console else File.read;
+pub const read = if (is_windows) readWin32Console else struct {
+    fn read(self: File, buffer: []u8) !usize {
+        return std.posix.read(self.handle, buffer);
+    }
+}.read;


### PR DESCRIPTION
resolves #44 

I tested it on windows and it seems to work but ngl the migration was mostly done via AI.

Replace removed APIs for 0.16 compatibility:
- std.fs.File -> std.Io.File (all source files)
- std.fs.cwd() -> Io.Dir.cwd()
- Thread io parameter through all functions
- reader/writer/writeStreamingAll now take io param
- isTty(io), close(io)
- std.process.getEnvVarOwned -> std.c.getenv
- callconv(w.WINAPI) -> callconv(.winapi)
- BOOL comparisons use .FALSE instead of == 0
- Windows console externs declared locally (removed from std lib)
- ArrayListUnmanaged uses .empty instead of .{}
- writeAll -> writeStreamingAll(io, ...)
- stdin/stdout/stderr: File.stdin() instead of std.fs.File.stdin()

Fix build.zig.zon: includes/ -> include/ (directory name was wrong)